### PR TITLE
The return type from the print helper function should be Void, not Bool.

### DIFF
--- a/src/LIBLINEAR.jl
+++ b/src/LIBLINEAR.jl
@@ -83,7 +83,12 @@ let liblinear = C_NULL
 end
 
 # helper
-linear_print(str::Ptr{UInt8}) = verbosity && print(unsafe_string(str))
+function linear_print(str::Ptr{UInt8})
+    if verbosity
+        print(unsafe_string(str))
+    end
+    nothing
+end
 
 macro cachedsym(symname)
     cached = gensym()


### PR DESCRIPTION
A small bug in the 0.5 version of your Julia LIBLINEAR wrapper. The "verbosity && print(...)" shortcut causes the return type of the function to be Bool. Since the cfunction wrapper expects it to be Void this will cause any ccall into LIBLINEAR to fail. Fixed by reverting to the old verbose function syntax.