### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,5 @@
 if !is_windows()
-  cd(joinpath(Pkg.dir(), "LIBLINEAR", "deps", "liblinear-210"))
+  cd(joinpath(dirname(@__FILE__), "liblinear-210"))
   run(`make lib`)
   run(`cp liblinear.so.3 ../liblinear.so.3`)
 end

--- a/src/LIBLINEAR.jl
+++ b/src/LIBLINEAR.jl
@@ -69,7 +69,7 @@ let liblinear = C_NULL
     global get_liblinear
     function get_liblinear()
         if liblinear == C_NULL
-            libpath = joinpath(Pkg.dir(), "LIBLINEAR", "deps")
+            libpath = joinpath(dirname(@__FILE__), "..", "deps")
             libfile = is_windows() ?
                 joinpath(libpath, "liblinear$(Sys.WORD_SIZE).dll") :
                 joinpath(libpath, "liblinear.so.3")


### PR DESCRIPTION
so the package can be installed elsewhere