### PR TITLE
CI: bump the `setup-julia` action to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,15 @@ jobs:
             arch: x86
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # LIBLINEAR
 
 [![CI](https://github.com/innerlee/LIBLINEAR.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/innerlee/LIBLINEAR.jl/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/JuliaML/LIBLINEAR.jl/graph/badge.svg?token=wNqvTQNWY1)](https://codecov.io/gh/JuliaML/LIBLINEAR.jl)
 
 
 Julia bindings for [LIBLINEAR](https://www.csie.ntu.edu.tw/~cjlin/liblinear/).


### PR DESCRIPTION
Let's wait for https://github.com/julia-actions/cache/issues/109 too