### PR TITLE
Raise minimum supported julia version to 1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "LIBLINEAR"
 uuid = "2d691ee1-e668-5016-a719-b2531b85e0f5"
 authors = ["innerlee"]
 repo = "https://github.com/innerlee/LIBLINEAR.jl.git"
-version = "0.6.1"
+version = "0.7.0"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -10,7 +10,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 liblinear_jll = "275f1f90-abd2-5ca1-9ad8-abd4e3d66eb7"
 
 [compat]
-julia = "1.3"
+julia = "1.6"
 liblinear_jll = "~2.47.0"
 
 [extras]


### PR DESCRIPTION
This is necessary in order to work with LIBLINEAR 2.47

Resolves #30 