### PR TITLE
Exclude 32-bit macos from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
         arch:
           - x64
           - x86
+        exclude:
+          - os: macos-latest
+            arch: x86
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
there aren't builds for this. Fixes the CI issue seen in #32 